### PR TITLE
Replace die() with wp_die() for Ajax.php file

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -15,5 +15,9 @@ function ajax_sample_sum_callback()
 
     echo $total;
 
-    die();
+    /**
+     * Use wp_die() instead of exit() or die(). exit() or die()
+     * will returns additional 0 char in Ajax response
+     */
+    wp_die();
 }


### PR DESCRIPTION
Based on Codex, we need to use wp_die() instead of exit() or die(). They will return 0 char in every Ajax response. 
